### PR TITLE
Fix mobile navigation

### DIFF
--- a/assets/css/starter-template.css
+++ b/assets/css/starter-template.css
@@ -10,6 +10,7 @@ body {
   position: relative;
   bottom: 32px;
   display: block;
+  clear: both;
 }
 
 .jump-anchor[name='privacy'] {

--- a/assets/css/starter-template.css
+++ b/assets/css/starter-template.css
@@ -5,3 +5,13 @@ body {
   padding: 40px 15px;
   text-align: center;
 }
+
+.jump-anchor {
+  position: relative;
+  bottom: 32px;
+  display: block;
+}
+
+.jump-anchor[name='privacy'] {
+  bottom: 53px;
+}

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1,0 +1,7 @@
+$(document).ready(function(){
+  $('ul.nav').click(function(){
+    $(this).closest('.navbar-collapse')
+      .removeClass('in')
+      .addClass('out');
+  });
+});

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     <link href="http://detroitwaterproject.org/assets/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- Custom styles for this template -->
-    <link href="http://detroitwaterproject.org/assets/css/starter-template.css" rel="stylesheet">
+    <link href="assets/css/starter-template.css" rel="stylesheet">
 
     <!-- Just for debugging purposes. Don't actually copy these 2 lines! -->
     <!--[if lt IE 9]><script src="http://detroitwaterproject.org/assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
@@ -136,7 +136,8 @@
         </p>
       </div>
 
-      <div id="help-a-resident" class="col-md-8 col-md-offset-2" style="margin-bottom: 25px;">
+      <a class="jump-anchor" name="help-a-resident"></a>
+      <div class="col-md-8 col-md-offset-2" style="margin-bottom: 25px;">
         <hr />
         <h3 class="blue-text">How this works (for donors)</h3>
         <p>
@@ -168,14 +169,16 @@
         </form>
       </div>
 
-      <div id="get-help" class="col-md-8 col-md-offset-2" style="margin-bottom: 25px;">
+      <a class="jump-anchor" name="get-help"></a>
+      <div class="col-md-8 col-md-offset-2" style="margin-bottom: 25px;">
         <hr />
         <h3 class="blue-text">Do you need help with your Detroit water bill?</h3>
         Let us know that you need help <a href="http://bit.ly/detroit-water-help">here</a> for one-time assistance of up to $1500. <em>No paperwork needed.</em>
         <hr />
       </div>
 
-      <div id="privacy" class="col-md-8 col-md-offset-2" style="margin-bottom: 25px;">
+      <a class="jump-anchor" name="privacy"></a>
+      <div class="col-md-8 col-md-offset-2" style="margin-bottom: 25px;">
         <h3 class="blue-text">How is privacy protected?</h3>
         <p>
           We <em>only</em> share information donors need to get matched to people to help with bills. <strong>Here's
@@ -189,7 +192,8 @@
         </p>
       </div>
 
-      <div id="press" class="col-md-8 col-md-offset-2" style="margin-bottom: 25px;">
+      <a class="jump-anchor" name="press"></a>
+      <div class="col-md-8 col-md-offset-2" style="margin-bottom: 25px;">
         <hr />
         <h3 class="blue-text">Selected press</h3>
         <p>
@@ -291,7 +295,8 @@
         </p>
       </div>
 
-      <div id="team" class="col-md-8 col-md-offset-2" style="margin-bottom: 25px;">
+      <a class="jump-anchor" name="team"></a>
+      <div class="col-md-8 col-md-offset-2" style="margin-bottom: 25px;">
         <hr />
         <h3 class="blue-text">The Team</h3>
         <p>
@@ -315,7 +320,8 @@
         </p>
       </div>
 
-      <div id="faqs" class="col-md-8 col-md-offset-2" style="margin-bottom: 25px;">
+      <a class="jump-anchor" name="faqs"></a>
+      <div class="col-md-8 col-md-offset-2" style="margin-bottom: 25px;">
         <hr />
         <h3 class="blue-text">Frequently Asked Questions</h3><br />
         <p>
@@ -363,7 +369,8 @@
         </div>
       </div>
 
-      <div id="contact" class="col-md-8 col-md-offset-2" style="margin-bottom: 25px;">
+      <a class="jump-anchor" name="contact"></a>
+      <div class="col-md-8 col-md-offset-2" style="margin-bottom: 25px;">
         <hr />
         <h3 class="blue-text">Get in touch. We're listening.</h3>
         <p>
@@ -396,5 +403,6 @@
     <!-- Placed at the end of the document so the pages load faster -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="http://detroit-water-project.herokuapp.com/assets/js/bootstrap.min.js"></script>
+    <script src="assets/js/custom.js"></script>
   </body>
 </html>


### PR DESCRIPTION
One thing that really bugs me about Bootstrap's mobile nav menu is that it doesn't collapse when you tap a link. I just navigated somewhere, and now I want to read it, Twitter Bootstrap!

So this commit adds a JavaScript file containing a function that collapses it when tapped on. 

One other issue I ran into with the mobile nav is that when you jump to a section, the title is hidden because of the offset of the height of the persistent top navbar. So this commit also adds jump anchors that compensate for that. 

One weird thing was that the privacy anchor needed extra compensation. Not sure why.

Lastly, you had coded absolute links (on the detroitwaterproject.org domain) to your assets, so it wasn't possible to develop this locally while adding to those files without making those links relative. So I did that. (See the diff on line 28 of `index.html`, for example.) Not sure if making those relative will break anything on your end, like if you've got some DNS cleverness going on or something. But provided those are all hosted in the same directory, it should be good to go!

**EDIT**

Also added a `clear` property on the links to compensate for Boostrap's grid and floats.
