### PR TITLE
Removing closing PHP tag

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,1 +1,1 @@
-<?php echo file_get_contents("index.html"); ?>
+<?php echo file_get_contents("index.html");


### PR DESCRIPTION
This is a trivial change. It is considered a PHP best practice to omit the closing PHP tag, lest there is whitespace after it. From http://php.net/manual/en/language.basic-syntax.phptags.php:

> If a file is pure PHP code, it is preferable to omit the PHP closing tag at the end of the file. This prevents accidental whitespace or new lines being added after the PHP closing tag, which may cause unwanted effects because PHP will start output buffering when there is no intention from the programmer to send any output at that point in the script.
