### PR TITLE
brought change in bootstrap core css.

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     <title>Detroit Water Project - Help a Detroit resident with their water bill!</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="http://detroitwaterproject.org/assets/css/bootstrap.min.css" rel="stylesheet">
+    <link href="assets/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- Custom styles for this template -->
     <link href="assets/css/starter-template.css" rel="stylesheet">


### PR DESCRIPTION
"assets/css/bootstrap.min.css" works better than "detroitwaterproject.org/assets/css/bootstrap.min.css".